### PR TITLE
Review by 284km

### DIFF
--- a/lib/transpose.rb
+++ b/lib/transpose.rb
@@ -1,4 +1,4 @@
-def transport(source)
+def transpose(source)
   array = source.split("\n").map {|s| s.split(" ")}
   rows_count = array.first.count
 

--- a/lib/transpose.rb
+++ b/lib/transpose.rb
@@ -1,11 +1,14 @@
 def transpose(source)
-  array = source.split("\n").map {|s| s.split(" ")}
-  rows_count = array.first.count
+  transposed_hash = transposed_hash_of(source)
+  string_of(transposed_hash)
+end
 
-  transported_array = []
-  0.upto(rows_count - 1) do |i|
-    transported_array << array.map {|a| a[i]}
-  end
+private
 
-  transported_array.map {|s| s.join(" ")}.join("\n")
+def transposed_hash_of(source)
+  source.split("\n").map(&:split).transpose
+end
+
+def string_of(transposed_hash)
+  transposed_hash.map{|a| a.join("\s")}.join("\n")
 end

--- a/test/transpose_test.rb
+++ b/test/transpose_test.rb
@@ -1,14 +1,14 @@
 require 'minitest/autorun'
-require './lib/transport'
+require './lib/transpose'
 
-class TransportTest < MiniTest::Test
-  def test_transport
+class TransposeTest < MiniTest::Test
+  def test_transpose
     input = "1 2 3\n4 5 6\n7 8 9"
     output = "1 4 7\n2 5 8\n3 6 9"
-    assert_equal output, transport(input)
+    assert_equal output, transpose(input)
 
     input = "1 2 3\n4 5 6\n7 8 9\n10 11 12"
     output = "1 4 7 10\n2 5 8 11\n3 6 9 12"
-    assert_equal output, transport(input)
+    assert_equal output, transpose(input)
   end
 end


### PR DESCRIPTION
まずメソッド名ですが、この場合 transpose の方が適切ではないかと思いました。

以下は 90af4a4 についてです。

String#split は引数を渡さない場合デフォルトで、先頭と末尾の空白を除いたうえで、空白文字列で分割します。
そのため、`.map(&:split)` のみで済みます。

* [instance method String#split (Ruby 2.4.0)](https://docs.ruby-lang.org/ja/latest/method/String/i/split.html)

行と列の入れ替えには、Array#transpose を使うと、タケシがここでやりたかったことがそのまま実現出来ていると思います。

* [instance method Array#transpose (Ruby 2.4.0)](https://docs.ruby-lang.org/ja/latest/method/Array/i/transpose.html)

最後に string に戻す処理はタケシのコードと同じですね。
さすがにこれらを一行で書くのは分かり辛いと思ったので（以下のように）、
転置した hash を作るまでと、その後 string に戻す処理をそれぞれプライベートメソッドに分けてみました。メソッド名から何の処理をしているか、想像しやすくなったと思います。

```
source.split("\n").map(&:split).transpose.map{|a| a.join("\s")}.join("\n")
```
