### PR TITLE
ruby-problem-201712 コードレビュー

### DIFF
--- a/lib/transport.rb
+++ b/lib/transport.rb
@@ -1,11 +1,5 @@
 def transport(source)
   array = source.split("\n").map {|s| s.split(" ")}
-  rows_count = array.first.count
-
-  transported_array = []
-  0.upto(rows_count - 1) do |i|
-    transported_array << array.map {|a| a[i]}
-  end
-
+  transported_array = array.transpose
   transported_array.map {|s| s.join(" ")}.join("\n")
 end


### PR DESCRIPTION
タケシさん
以下レビューです。
* Arrayの転置はメソッドが用意されているのでそれを使いましょう
https://docs.ruby-lang.org/ja/latest/class/Array.html#I_TRANSPOSE
「こういうことするメソッドありそう」と思った時は探してみたら大概いいもの見つかるので、探してみると良いです
https://ref.xaio.jp/ruby/classes/array

あと、今回は修正しませんでしたが、今後の参考までに
* メソッドの分け方について
sourceをArrayに変換する、Arrayを戻り値の形に変換する、はメソッド化することで処理に名前をつけられるので、何をやってるコードかすぐわかるようになるのでおすすめです。
ただ、今回はコード量が少なく、あえてメソッドを分けるほどではないので、今の書き方が良いと思います。
* String.splitは引数なしなら空文字で分割されます
https://docs.ruby-lang.org/ja/latest/class/String.html#I_SPLIT
つまり、`array = source.split("\n").map(&:split)`と書けてちょっとスッキリします。
ただ、前のsplitは引数ありで、後ろのsplitは引数なしだとちょっと不思議に見えるかもしれないので、今の書き方で良いと思います。