### PR TITLE
リファクタリング by りおん

### DIFF
--- a/lib/transport.rb
+++ b/lib/transport.rb
@@ -1,8 +1,11 @@
+# 文字列で表現された行列を転置して、文字列形式で返す
+#   入力例: "1 2 3\n4 5 6\n7 8 9\n10 11 12"
+#   出力例: "1 4 7 10\n2 5 8 11\n3 6 9 12"
 def transport(source)
   source
       .each_line
-      .map {|s| s.split(" ")}
+      .map(&:split)
       .transpose
-      .map {|s| s.join(" ")}
+      .map {|ary| ary.join(" ")}
       .join("\n")
 end

--- a/lib/transport.rb
+++ b/lib/transport.rb
@@ -1,11 +1,7 @@
 def transport(source)
-  array = source.split("\n").map {|s| s.split(" ")}
-  rows_count = array.first.count
+  org_array = source.each_line.map {|s| s.split(" ")}
 
-  transported_array = []
-  0.upto(rows_count - 1) do |i|
-    transported_array << array.map {|a| a[i]}
-  end
+  transported_array = org_array.transpose
 
   transported_array.map {|s| s.join(" ")}.join("\n")
 end

--- a/lib/transport.rb
+++ b/lib/transport.rb
@@ -1,11 +1,11 @@
 # 文字列で表現された行列を転置して、文字列形式で返す
-#   入力例: "1 2 3\n4 5 6\n7 8 9\n10 11 12"
-#   出力例: "1 4 7 10\n2 5 8 11\n3 6 9 12"
+# ex) 入力: "1 2 3\n4 5 6\n7 8 9\n10 11 12"
+#     出力: "1 4 7 10\n2 5 8 11\n3 6 9 12"
 def transport(source)
   source
-      .each_line
-      .map(&:split)
+      .split("\n")
+      .map {|s| s.split(" ")}
       .transpose
-      .map {|ary| ary.join(" ")}
+      .map {|a| a.join(" ")}
       .join("\n")
 end

--- a/lib/transport.rb
+++ b/lib/transport.rb
@@ -1,7 +1,8 @@
 def transport(source)
-  org_array = source.each_line.map {|s| s.split(" ")}
-
-  transported_array = org_array.transpose
-
-  transported_array.map {|s| s.join(" ")}.join("\n")
+  source
+      .each_line
+      .map {|s| s.split(" ")}
+      .transpose
+      .map {|s| s.join(" ")}
+      .join("\n")
 end

--- a/test/transport_test.rb
+++ b/test/transport_test.rb
@@ -8,11 +8,12 @@ class TransportTest < MiniTest::Test
       4 5 6
       7 8 9
     EOS
-    assert_equal <<~EOS.chomp, transport(input)
+    expect = <<~EOS.chomp
       1 4 7
       2 5 8
       3 6 9
     EOS
+    assert_equal expect, transport(input)
 
     input = <<~EOS.chomp
       1 2 3
@@ -20,10 +21,13 @@ class TransportTest < MiniTest::Test
       7 8 9
       10 11 12
     EOS
-    assert_equal <<~EOS.chomp, transport(input)
+    expect = <<~EOS.chomp
       1 4 7 10
       2 5 8 11
       3 6 9 12
     EOS
+    assert_equal expect, transport(input)
+
+    # assert_equal "1 4\n2 5\n3 6", transport("1 2\r\n3 4\r5 6")
   end
 end

--- a/test/transport_test.rb
+++ b/test/transport_test.rb
@@ -27,7 +27,5 @@ class TransportTest < MiniTest::Test
       3 6 9 12
     EOS
     assert_equal expect, transport(input)
-
-    # assert_equal "1 4\n2 5\n3 6", transport("1 2\r\n3 4\r5 6")
   end
 end

--- a/test/transport_test.rb
+++ b/test/transport_test.rb
@@ -3,12 +3,27 @@ require './lib/transport'
 
 class TransportTest < MiniTest::Test
   def test_transport
-    input = "1 2 3\n4 5 6\n7 8 9"
-    output = "1 4 7\n2 5 8\n3 6 9"
-    assert_equal output, transport(input)
+    input = <<~EOS.chomp
+      1 2 3
+      4 5 6
+      7 8 9
+    EOS
+    assert_equal <<~EOS.chomp, transport(input)
+      1 4 7
+      2 5 8
+      3 6 9
+    EOS
 
-    input = "1 2 3\n4 5 6\n7 8 9\n10 11 12"
-    output = "1 4 7 10\n2 5 8 11\n3 6 9 12"
-    assert_equal output, transport(input)
+    input = <<~EOS.chomp
+      1 2 3
+      4 5 6
+      7 8 9
+      10 11 12
+    EOS
+    assert_equal <<~EOS.chomp, transport(input)
+      1 4 7 10
+      2 5 8 11
+      3 6 9 12
+    EOS
   end
 end

--- a/test/transport_test.rb
+++ b/test/transport_test.rb
@@ -28,4 +28,14 @@ class TransportTest < MiniTest::Test
     EOS
     assert_equal expect, transport(input)
   end
+
+  def test_compare_heredoc_to_string
+    literal = "1 2 3\n4 5 6\n7 8 9"
+    heredoc = <<~EOS.chomp
+      1 2 3
+      4 5 6
+      7 8 9
+    EOS
+    assert_equal heredoc, literal
+  end
 end

--- a/test/transport_test.rb
+++ b/test/transport_test.rb
@@ -26,16 +26,5 @@ class TransportTest < MiniTest::Test
       2 5 8 11
       3 6 9 12
     EOS
-    assert_equal expect, transport(input)
-  end
-
-  def test_compare_heredoc_to_string
-    literal = "1 2 3\n4 5 6\n7 8 9"
-    heredoc = <<~EOS.chomp
-      1 2 3
-      4 5 6
-      7 8 9
-    EOS
-    assert_equal heredoc, literal
   end
 end

--- a/test/transport_test.rb
+++ b/test/transport_test.rb
@@ -26,5 +26,6 @@ class TransportTest < MiniTest::Test
       2 5 8 11
       3 6 9 12
     EOS
+    assert_equal expect, transport(input)
   end
 end


### PR DESCRIPTION
## `Array#transpose` を使う
Arrayクラスには行列を転置するメソッド `transpose` が既に用意されています。

## メソッドチェーン化する
一時変数を撤廃することができ、かつやりたいことがより明確に記述できます。

## [テストコード] ヒアドキュメントを使って行列を表現する
ヒアドキュメントを使えば、より明確に行列を表現できます。
※ただし、テストコードが長くなるので、テストコード量によっては\nを使って1行で表現したほうがいい場合もあるかと。