### PR TITLE
refactor by popmac

### DIFF
--- a/lib/transport.rb
+++ b/lib/transport.rb
@@ -1,11 +1,4 @@
 def transport(source)
-  array = source.split("\n").map {|s| s.split(" ")}
-  rows_count = array.first.count
-
-  transported_array = []
-  0.upto(rows_count - 1) do |i|
-    transported_array << array.map {|a| a[i]}
-  end
-
-  transported_array.map {|s| s.join(" ")}.join("\n")
+  array = source.split("\n").map(&:split)
+  array.transpose.map {|s| s.join(" ")}.join("\n")
 end


### PR DESCRIPTION
## 主旨
- Rubyが既に用意しているメソッドやイディオムを使うことで、コードを短くできそうだったので、transportメソッドを以下のように変更しました😄

## transportメソッドの変更内容
- ２行目では、splitメソッドの引数を省略して、mapメソッドで`&:`のイディオムを使用するようにしました
  - splitメソッドは引数を省略すると、「空白文字による分割」になります
  - splitメソッドの引数が省略できることで、mapメソッドで`&:`のイディオムが使用できるようになりました
- 3行目では、Rubyで用意されているArray#transposeメソッドを、行と列の入れ替えを行うために使用しました