### PR TITLE
Refactor by yuki3738

### DIFF
--- a/lib/transporse.rb
+++ b/lib/transporse.rb
@@ -1,13 +1,13 @@
-def transport(source)
+def transporse(source)
   two_dimensional_arrays = string_to_arrays(source)
-  transported_arrays = two_dimensional_arrays.transpose
-  arrays_to_string(transported_arrays)
+  transporsed_arrays = two_dimensional_arrays.transpose
+  arrays_to_string(transporsed_arrays)
 end
 
 private
 
 def string_to_arrays(source)
-  source.split("\n").map(&:split)
+  source.lines.map(&:split)
 end
 
 def arrays_to_string(arrays)

--- a/lib/transport.rb
+++ b/lib/transport.rb
@@ -1,11 +1,15 @@
 def transport(source)
-  array = source.split("\n").map {|s| s.split(" ")}
-  rows_count = array.first.count
+  two_dimensional_arrays = string_to_arrays(source)
+  transported_arrays = two_dimensional_arrays.transpose
+  arrays_to_string(transported_arrays)
+end
 
-  transported_array = []
-  0.upto(rows_count - 1) do |i|
-    transported_array << array.map {|a| a[i]}
-  end
+private
 
-  transported_array.map {|s| s.join(" ")}.join("\n")
+def string_to_arrays(source)
+  source.split("\n").map(&:split)
+end
+
+def arrays_to_string(arrays)
+  arrays.map {|array| array.join(" ")}.join("\n")
 end

--- a/test/transporse_test.rb
+++ b/test/transporse_test.rb
@@ -1,14 +1,14 @@
 require 'minitest/autorun'
-require './lib/transport'
+require './lib/transporse'
 
-class TransportTest < MiniTest::Test
-  def test_transport
+class TransporseTest < MiniTest::Test
+  def test_transporse
     input = "1 2 3\n4 5 6\n7 8 9"
     output = "1 4 7\n2 5 8\n3 6 9"
-    assert_equal output, transport(input)
+    assert_equal output, transporse(input)
 
     input = "1 2 3\n4 5 6\n7 8 9\n10 11 12"
     output = "1 4 7 10\n2 5 8 11\n3 6 9 12"
-    assert_equal output, transport(input)
+    assert_equal output, transporse(input)
   end
 end


### PR DESCRIPTION
# 変更点
##  1. transportメソッドの処理を以下のメソッドに分けました。
```map```とか```split```とか```join```とかいっぱいあって内容を把握するのに時間がかかるため。

### 配列を転地する処理
```Array#transpose```というメソッドがあるのでこちらを使うほうがよいと思いました。

### 行列textを二次元配列にする処理
```map {|s| s.split(" ")}```は```map(&:split)```と書き換えられます。
```split("\n").map(&:split)```は```lines.map(&:split)```と書き換えられます。
それぞれ簡潔になるのでこちらのほうがよいと思いました。

### 二次元配列を行列textにする処理
処理はタケシさんのコードそのままです。
一点、変数```s```ですがここにはArrayオブジェクトが入るので```array```としました。

## 2. 変数名、ファイル名、メソッド名など各所の名前を変更しました
* ```transport```は(...を運ぶ)といった意味で不適切に感じたため```transpose```(…を入れ換える)に変更しました。
* 2次元配列はArrayオブジェクトではありますが、複数のarrayが入ってるので各所```arrays```の方がパっと見で多次元配列だとわかるので良いと思いました。

