### PR TITLE
refactoring by Y-Fujikawa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,115 @@
+# Created by https://www.gitignore.io/api/ruby,rubymine+all
+
+### Ruby ###
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Used by dotenv library to load environment variables.
+# .env
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+### RubyMine+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-debug/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Ruby plugin and RubyMine
+/.rakeTasks
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+### RubyMine+all Patch ###
+# Ignores the whole idea folder
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+.idea/
+
+# End of https://www.gitignore.io/api/ruby,rubymine+all

--- a/lib/transpose.rb
+++ b/lib/transpose.rb
@@ -1,4 +1,4 @@
-def transport(source)
+def transpose(source)
   array = source.split("\n").map {|s| s.split(" ")}
   rows_count = array.first.count
 

--- a/lib/transpose.rb
+++ b/lib/transpose.rb
@@ -1,11 +1,5 @@
 def transpose(source)
   array = source.split("\n").map {|s| s.split(" ")}
-  rows_count = array.first.count
-
-  transported_array = []
-  0.upto(rows_count - 1) do |i|
-    transported_array << array.map {|a| a[i]}
-  end
-
+  transported_array = array.transpose
   transported_array.map {|s| s.join(" ")}.join("\n")
 end

--- a/test/transport_test.rb
+++ b/test/transport_test.rb
@@ -1,14 +1,14 @@
 require 'minitest/autorun'
-require './lib/transport'
+require './lib/transpose'
 
-class TransportTest < MiniTest::Test
-  def test_transport
+class TransposeTest < MiniTest::Test
+  def test_transpose
     input = "1 2 3\n4 5 6\n7 8 9"
     output = "1 4 7\n2 5 8\n3 6 9"
-    assert_equal output, transport(input)
+    assert_equal output, transpose(input)
 
     input = "1 2 3\n4 5 6\n7 8 9\n10 11 12"
     output = "1 4 7 10\n2 5 8 11\n3 6 9 12"
-    assert_equal output, transport(input)
+    assert_equal output, transpose(input)
   end
 end

--- a/test/transport_test.rb
+++ b/test/transport_test.rb
@@ -2,11 +2,13 @@ require 'minitest/autorun'
 require './lib/transpose'
 
 class TransposeTest < MiniTest::Test
-  def test_transpose
+  def test_transpose_3x3
     input = "1 2 3\n4 5 6\n7 8 9"
     output = "1 4 7\n2 5 8\n3 6 9"
     assert_equal output, transpose(input)
+  end
 
+  def test_transpose_4x4
     input = "1 2 3\n4 5 6\n7 8 9\n10 11 12"
     output = "1 4 7 10\n2 5 8 11\n3 6 9 12"
     assert_equal output, transpose(input)


### PR DESCRIPTION
- Arrayクラスに同様の処理ができるメソッドがあったため、置き換え
- テストメソッドに2つのテストが書かれていたため、分割してわかりやすくする
- 処理内容とクラス名が一致していなかったため、クラス名を変更